### PR TITLE
Add symlinking for setup.py-defined scripts and entry_points['console_scripts']

### DIFF
--- a/make_deb/resources/debian/links.j2
+++ b/make_deb/resources/debian/links.j2
@@ -1,0 +1,3 @@
+{% for script_name in scripts %}  
+/usr/share/python/{{name}}/bin/{{script_name}} /usr/local/bin/{{script_name}} 
+{% endfor %}  


### PR DESCRIPTION
This patch adds a `<package>.links` file to the `debian` folder, to set up
symlinks for scripts and entry_points described in `setup.py`. In addition,
it alters the method for parsing `setup.py` to be based on distutils
(setuptools is required to support the `entry_points['console_scripts]`-parsing).
