### PR TITLE
Changing default enconding for UTF-8 support

### DIFF
--- a/bin/make-deb
+++ b/bin/make-deb
@@ -5,6 +5,8 @@ import sys
 
 from make_deb import DebianConfiguration, DebianConfigurationException
 
+reload(sys)
+sys.setdefaultencoding('UTF8')
 
 def main():
     try:


### PR DESCRIPTION
Due to an UnicodeDecodeError exception, it was not possible to generate the debian/folder
