### PR TITLE
Support building Python 3 debs

### DIFF
--- a/bin/make-deb
+++ b/bin/make-deb
@@ -3,14 +3,44 @@
 import os
 import sys
 
+import click
+
 from make_deb import DebianConfiguration, DebianConfigurationException
 
 reload(sys)
 sys.setdefaultencoding('UTF8')
 
-def main():
+
+def get_dh_virtualenv_options(python, test):
+    dh_virtualenv_options = []
+    if not test:
+        dh_virtualenv_options.append('--no-test')
+    if python:
+        dh_virtualenv_options.append('--python ' + python)
+    return dh_virtualenv_options
+
+
+@click.command()
+@click.option('--python',
+              default=None,
+              metavar='/path/to/python',
+              help='Path to Python executable to use '
+                   '(e.g.: /usr/bin/python or /usr/bin/python3')
+@click.option('--python-version',
+              type=click.Choice(['2.x', '3.4', '3.5']),
+              default='2.x',
+              help='Python version')
+@click.option('--test/--no-test',
+              default=True,
+              help='Whether to run python setup.py test')
+def main(python, python_version, test):
+    dh_virtualenv_options = get_dh_virtualenv_options(python, test)
     try:
-        debconf = DebianConfiguration(os.getcwd())
+        debconf = DebianConfiguration(
+            os.getcwd(),
+            python_version=python_version,
+            dh_virtualenv_options=dh_virtualenv_options,
+        )
         debconf.render()
     except DebianConfigurationException as e:
         print(e)
@@ -18,6 +48,7 @@ def main():
 
     print("'debian' directory successfully placed at the root of your repository")
     return 0
+
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/bin/make-deb
+++ b/bin/make-deb
@@ -33,13 +33,17 @@ def get_dh_virtualenv_options(python, test):
 @click.option('--test/--no-test',
               default=True,
               help='Whether to run python setup.py test')
-def main(python, python_version, test):
+@click.option('--postinst-commands',
+              default=None,
+              help='Commands to put in postinst script')
+def main(python, python_version, test, postinst_commands):
     dh_virtualenv_options = get_dh_virtualenv_options(python, test)
     try:
         debconf = DebianConfiguration(
             os.getcwd(),
             python_version=python_version,
             dh_virtualenv_options=dh_virtualenv_options,
+            postinst_commands=postinst_commands,
         )
         debconf.render()
     except DebianConfigurationException as e:

--- a/make_deb/__init__.py
+++ b/make_deb/__init__.py
@@ -45,6 +45,7 @@ class DebianConfiguration(object):
         else:
             self.context.update({
                 "pre_depends_python": "python2.7-minimal | python2.6-minimal"})
+        self.context.update({"python_version": python_version})
         self.context.update({"dh_virtualenv_options": dh_virtualenv_options})
 
     def _context_from_git(self):

--- a/make_deb/__init__.py
+++ b/make_deb/__init__.py
@@ -32,12 +32,20 @@ class DebianConfiguration(object):
         "compat": 9,
     }
 
-    def __init__(self, rootdir):
+    def __init__(self, rootdir, python_version='2.x', dh_virtualenv_options=None):
         self.rootdir = rootdir
         self.context = self.DEFAULT_CONTEXT.copy()
         self.context.update({"date": datetime.datetime.now()})
         self.context.update(self._context_from_setuppy())
         self.context.update(self._context_from_git())
+        if python_version == '3.5':
+            self.context.update({"pre_depends_python": "python3.5"})
+        elif python_version == '3.4':
+            self.context.update({"pre_depends_python": "python3.4"})
+        else:
+            self.context.update({
+                "pre_depends_python": "python2.7-minimal | python2.6-minimal"})
+        self.context.update({"dh_virtualenv_options": dh_virtualenv_options})
 
     def _context_from_git(self):
         try:

--- a/make_deb/__init__.py
+++ b/make_deb/__init__.py
@@ -32,7 +32,9 @@ class DebianConfiguration(object):
         "compat": 9,
     }
 
-    def __init__(self, rootdir, python_version='2.x', dh_virtualenv_options=None):
+    def __init__(self, rootdir,
+                 python_version='2.x', dh_virtualenv_options=None,
+                 postinst_commands=None):
         self.rootdir = rootdir
         self.context = self.DEFAULT_CONTEXT.copy()
         self.context.update({"date": datetime.datetime.now()})
@@ -47,6 +49,7 @@ class DebianConfiguration(object):
                 "pre_depends_python": "python2.7-minimal | python2.6-minimal"})
         self.context.update({"python_version": python_version})
         self.context.update({"dh_virtualenv_options": dh_virtualenv_options})
+        self.context.update({"postinst_commands": postinst_commands})
 
     def _context_from_git(self):
         try:
@@ -115,5 +118,14 @@ class DebianConfiguration(object):
         ).render(self.context)
 
         trigger_filename = "%s.triggers" % self.context['name']
+        with open(os.path.join(output_dir, trigger_filename), "w") as f:
+            f.write(trigger_content+"\n")
+
+        trigger_content = Template(
+            resource_string("make_deb", "resources/debian/postinst.j2").
+            decode('utf-8')
+        ).render(self.context)
+
+        trigger_filename = "%s.postinst" % self.context['name']
         with open(os.path.join(output_dir, trigger_filename), "w") as f:
             f.write(trigger_content+"\n")

--- a/make_deb/resources/debian/control.j2
+++ b/make_deb/resources/debian/control.j2
@@ -7,7 +7,7 @@ Standards-Version: 3.9.5
 
 Package: {{ name }}
 Architecture: any
-Pre-Depends: dpkg (>= 1.16.1), python2.7-minimal | python2.6-minimal, ${misc:Pre-Depends}
+Pre-Depends: dpkg (>= 1.16.1), {{ pre_depends_python }}, ${misc:Pre-Depends}
 Depends: ${python:Depends}, ${misc:Depends}
 Description: {{ description }}
  {{ description }}

--- a/make_deb/resources/debian/postinst.j2
+++ b/make_deb/resources/debian/postinst.j2
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+#DEBHELPER#
+
+{{ postinst_commands }}

--- a/make_deb/resources/debian/rules.j2
+++ b/make_deb/resources/debian/rules.j2
@@ -2,3 +2,7 @@
 
 %:
 	dh $@ --with python-virtualenv
+{% if dh_virtualenv_options %}
+override_dh_virtualenv:
+	dh_virtualenv {{ ' '.join(dh_virtualenv_options) }}
+{% endif %}

--- a/make_deb/resources/debian/triggers.j2
+++ b/make_deb/resources/debian/triggers.j2
@@ -1,8 +1,14 @@
 # Register interest in Python interpreter changes (Python 2 for now); and
 # don't make the Python package dependent on the virtualenv package
 # processing (noawait)
+{% if python_version == '3.5' %}
+interest-noawait /usr/bin/python3.5
+{% elif python_version == '3.4' %}
+interest-noawait /usr/bin/python3.4
+{% else %}
 interest-noawait /usr/bin/python2.6
 interest-noawait /usr/bin/python2.7
+{% endif %}
 
 # Also provide a symbolic trigger for all dh-virtualenv packages
 interest dh-virtualenv-interpreter-update

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 -f file:///Users/systemizer/.cache/wheel
+click==6.6
 Jinja2==2.7.3
 MarkupSafe==0.23
 wheel==0.24.0

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,6 @@ setup(
             ]
         },
     scripts=['bin/make-deb'],
-    install_requires=['future', 'Jinja2'],
+    install_requires=['click', 'future', 'Jinja2'],
     zip_safe=False
 )


### PR DESCRIPTION
and add options for customizability

```
$ make-deb --help
Usage: make-deb [OPTIONS]

Options:
  --python /path/to/python        Path to Python executable to use (e.g.:
                                  /usr/bin/python or /usr/bin/python3
  --python-version [2.x|3.4|3.5]  Python version
  --test / --no-test              Whether to run python setup.py test
  --postinst-commands TEXT        Commands to put in postinst script
  --help                          Show this message and exit.
```

```
$ rm -rf debian
$ make-deb && cat debian/rules
'debian' directory successfully placed at the root of your repository

%:
	dh $@ --with python-virtualenv
```

```
$ rm -rf debian
$ make-deb --no-test --python=/usr/bin/python3 --python-version=3.5 \
>     --postinst-commands='mkdir -p /var/log/sm'
'debian' directory successfully placed at the root of your repository

$ grep Pre-Depends debian/control
Pre-Depends: dpkg (>= 1.16.1), python3.5, ${misc:Pre-Depends}

$ cat debian/rules
#!/usr/bin/make -f

%:
	dh $@ --with python-virtualenv

override_dh_virtualenv:
	dh_virtualenv --no-test --python /usr/bin/python3

$ cat debian/smbot.triggers
# Register interest in Python interpreter changes (Python 2 for now); and
# don't make the Python package dependent on the virtualenv package
# processing (noawait)

interest-noawait /usr/bin/python3.5


# Also provide a symbolic trigger for all dh-virtualenv packages
interest dh-virtualenv-interpreter-update

$ cat debian/smbot.postinst
#!/bin/sh

#DEBHELPER#

mkdir -p /var/log/sm
```

Cc: @bszonye, @theaisforannie